### PR TITLE
Plain text tools, unfocused note border, and Vision OCR for image notes

### DIFF
--- a/StickNote/AppState.swift
+++ b/StickNote/AppState.swift
@@ -10,6 +10,7 @@ final class AppState {
     static let shared: AppState = AppState()
     @Default(.deleteToTrashBin) var deleteToTrashBin
     @Default(.trimAfterPaste) var trimAfterPaste
+    @Default(.wrapLongLinesAfterPaste) var wrapLongLinesAfterPaste
 
     var sharedModelContainer: ModelContainer
     var context: ModelContext
@@ -87,7 +88,13 @@ final class AppState {
         }
         if let text = NSPasteboard.general.string(forType: .string) {
             if !text.isEmpty {
-                let content = trimAfterPaste ? text.trimmingNoteWhitespace() : text
+                var content = text
+                if trimAfterPaste {
+                    content = content.trimmingNoteWhitespace()
+                }
+                if wrapLongLinesAfterPaste {
+                    content = content.wrappingLongLinesAtWordBoundaries()
+                }
                 let note = Note(layout: getDefaultLayout(), text: content)
                 note.showOnAllSpaces = Defaults[.showOnAllSpaces]
                 self.context.insert(note)

--- a/StickNote/AppState.swift
+++ b/StickNote/AppState.swift
@@ -87,10 +87,8 @@ final class AppState {
         }
         if let text = NSPasteboard.general.string(forType: .string) {
             if !text.isEmpty {
-                let note = Note(layout: getDefaultLayout(), text: text)
-                if (trimAfterPaste){
-                    note.trim()
-                }
+                let content = trimAfterPaste ? text.trimmingNoteWhitespace() : text
+                let note = Note(layout: getDefaultLayout(), text: content)
                 note.showOnAllSpaces = Defaults[.showOnAllSpaces]
                 self.context.insert(note)
                 

--- a/StickNote/Models/Note.swift
+++ b/StickNote/Models/Note.swift
@@ -77,13 +77,6 @@ final class Note: NoteAppearance, Identifiable {
         self.fontSize = layout.fontSize
     }
     
-    func trim() {
-        text = text
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .joined(separator: "\n")
-    }
-
     func clearMarkdownDisplayFrame() {
         markdownFrameWidth = nil
         markdownFrameHeight = nil

--- a/StickNote/Note/NoteView.swift
+++ b/StickNote/Note/NoteView.swift
@@ -334,6 +334,10 @@ struct NoteView: View {
                     note.text = note.text.trimmingNoteWhitespace()
                     updateWindowSize()
                 }
+                Button("Wrap lines") {
+                    note.text = note.text.wrappingLongLinesAtWordBoundaries()
+                    updateWindowSize()
+                }
             }
         }
 

--- a/StickNote/Note/NoteView.swift
+++ b/StickNote/Note/NoteView.swift
@@ -22,6 +22,8 @@ struct NoteView: View {
     @State private var note: Note
     @State private var isCollapsed: Bool = false
     @State private var nsWindow: NSWindow?
+    /// Key window (focused note); used for a light border when unfocused so edge is visible without shadow.
+    @State private var isKeyWindow = true
     @State private var isEditing: Bool
     @FocusState private var isTextEditorFocused: Bool
     @State private var selection: TextSelection?
@@ -130,11 +132,28 @@ struct NoteView: View {
         .background(WindowClickOutsideListener(isEditing: $isEditing))
         .background(windowAccessor)
         .frame(width: resolvedFrameWidth, height: resolvedFrameHeight)
+        .overlay {
+            if !isKeyWindow {
+                Rectangle()
+                    .strokeBorder(Color.primary.opacity(0.14), lineWidth: 1)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { n in
+            guard let w = n.object as? NSWindow, w === nsWindow else { return }
+            isKeyWindow = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)) { n in
+            guard let w = n.object as? NSWindow, w === nsWindow else { return }
+            isKeyWindow = false
+        }
         .onAppear {
             if note.isImageNote { isEditing = false }
             updateWindowSize()
         }
         .onChange(of: nsWindow) { _, window in
+            if let window {
+                isKeyWindow = window.isKeyWindow
+            }
             guard window != nil else { return }
             DispatchQueue.main.async { syncLaunchOriginFromWindowOnce() }
         }

--- a/StickNote/Note/NoteView.swift
+++ b/StickNote/Note/NoteView.swift
@@ -29,6 +29,11 @@ struct NoteView: View {
     @State private var selection: TextSelection?
     @State private var showConfirmation = false
     @State private var showHideUntilSheet = false
+    @State private var showOCRConfirm = false
+    @State private var isOCRRunning = false
+    @State private var showOCREmptyAlert = false
+    @State private var showOCRFailureAlert = false
+    @State private var ocrErrorMessage = ""
     @State private var width: CGFloat
     @State private var height: CGFloat
     /// Cancels stale async markdown measurements when the note changes again before layout finishes.
@@ -125,6 +130,26 @@ struct NoteView: View {
         ) {
             deleteConfirmationButtons
         }
+        .confirmationDialog(
+            "Replace this image note with recognized text? This cannot be undone.",
+            isPresented: $showOCRConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Replace", role: .destructive) {
+                startOCRFromImage()
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .alert("No text recognized", isPresented: $showOCREmptyAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("No text could be recognized in this image. Try a clearer or higher-resolution image.")
+        }
+        .alert("Text recognition failed", isPresented: $showOCRFailureAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(ocrErrorMessage)
+        }
         .sheet(isPresented: $showHideUntilSheet) {
             HideNoteUntilSheet(note: note)
         }
@@ -136,6 +161,15 @@ struct NoteView: View {
             if !isKeyWindow {
                 Rectangle()
                     .strokeBorder(Color.primary.opacity(0.14), lineWidth: 1)
+            }
+        }
+        .overlay {
+            if note.isImageNote && isOCRRunning {
+                ZStack {
+                    Color.black.opacity(0.22)
+                    ProgressView()
+                        .controlSize(.regular)
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { n in
@@ -332,6 +366,15 @@ struct NoteView: View {
             Label("Copy to clipboard", systemImage: "doc.on.doc")
         }
 
+        if note.isImageNote, note.imageData != nil {
+            Button {
+                showOCRConfirm = true
+            } label: {
+                Label("Recognize Text (OCR)…", systemImage: "text.viewfinder")
+            }
+            .disabled(isOCRRunning)
+        }
+
         if !note.isImageNote {
             Toggle(
                 isOn: Binding(
@@ -463,6 +506,53 @@ struct NoteView: View {
         } else {
             self.nsWindow?.close()
             AppState.shared.deleteNote(note)
+        }
+    }
+
+    private func startOCRFromImage() {
+        guard let data = note.imageData, !data.isEmpty else {
+            ocrErrorMessage = ImageOCR.Failure.couldNotCreateCGImage.localizedDescription
+            showOCRFailureAlert = true
+            return
+        }
+        isOCRRunning = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = Result { try ImageOCR.recognizeText(from: data) }
+            DispatchQueue.main.async {
+                isOCRRunning = false
+                switch result {
+                case .success(let text):
+                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if trimmed.isEmpty {
+                        showOCREmptyAlert = true
+                    } else {
+                        applyRecognizedOCRText(text)
+                    }
+                case .failure(let error):
+                    ocrErrorMessage = error.localizedDescription
+                    showOCRFailureAlert = true
+                }
+            }
+        }
+    }
+
+    private func applyRecognizedOCRText(_ text: String) {
+        note.text = text
+        note.isImageNote = false
+        note.imageData = nil
+        note.imageFrameWidth = nil
+        note.imageFrameHeight = nil
+        note.isMarkdown = false
+        note.clearMarkdownDisplayFrame()
+        note.applyLikelyMarkdownFlagFromContent()
+        note.isMinimized = false
+        isCollapsed = false
+        isEditing = true
+        note.updatedAt = Date.now
+        try? AppState.shared.context.save()
+        updateWindowSize()
+        DispatchQueue.main.async {
+            isTextEditorFocused = true
         }
     }
     

--- a/StickNote/Note/NoteView.swift
+++ b/StickNote/Note/NoteView.swift
@@ -328,6 +328,15 @@ struct NoteView: View {
             }
         }
 
+        if !note.isImageNote && !note.isMarkdown {
+            Menu("Text", systemImage: "text.alignleft") {
+                Button("Trim whitespaces") {
+                    note.text = note.text.trimmingNoteWhitespace()
+                    updateWindowSize()
+                }
+            }
+        }
+
         Button {
             AppState.shared.exportNoteToFile(note)
         } label: {

--- a/StickNote/Settings/Defaults.swift
+++ b/StickNote/Settings/Defaults.swift
@@ -9,6 +9,8 @@ extension Defaults.Keys {
     static let maximizeOnHover = Key<Bool>("maximize-on-hover", default: true)
     static let maximizeOnEdit = Key<Bool>("maximize-on-edit", default: false)
     static let trimAfterPaste = Key<Bool>("trim-after-paste", default: false)
+    /// Word-wrap long lines when pasting a new note from the clipboard (after trim, if enabled).
+    static let wrapLongLinesAfterPaste = Key<Bool>("wrap-long-lines-after-paste", default: false)
     static let showNotesCount = Key<Bool>("show-notes-count", default: true)
     static let showMenuBarIcon = Key<Bool>("show-menu-bar-icon", default: true)
 }

--- a/StickNote/Settings/SettingsView.swift
+++ b/StickNote/Settings/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 enum SettingsWindowMetrics {
     static let width: CGFloat = 400
     /// Fixed height: fits General (shortcuts) and Note tabs without excess empty space.
-    static let height: CGFloat = 450
+    static let height: CGFloat = 500
 }
 
 struct SettingsView: View {
@@ -17,6 +17,7 @@ struct SettingsView: View {
 
     @Default(.confirmOnDelete) var confirmOnDelete
     @Default(.trimAfterPaste) var trimAfterPaste
+    @Default(.wrapLongLinesAfterPaste) var wrapLongLinesAfterPaste
     @Default(.showOnAllSpaces) var showOnAllSpaces
     @Default(.deleteToTrashBin) var deleteToTrashBin
     @Default(.maximizeOnHover) var maximizeOnHover
@@ -82,6 +83,7 @@ struct SettingsView: View {
                     }
                     Section("Paste note") {
                         Toggle("Trim whitespaces", isOn: $trimAfterPaste)
+                        Toggle("Wrap long lines", isOn: $wrapLongLinesAfterPaste)
                     }
                 }
                 .formStyle(.grouped)

--- a/StickNote/Utils/ImageOCR.swift
+++ b/StickNote/Utils/ImageOCR.swift
@@ -1,0 +1,65 @@
+import AppKit
+import Foundation
+import Vision
+
+/// On-device text recognition for embedded PNG image notes (``Note/imageData``).
+enum ImageOCR {
+
+    enum Failure: LocalizedError {
+        case couldNotCreateCGImage
+
+        var errorDescription: String? {
+            switch self {
+            case .couldNotCreateCGImage:
+                return "Could not read the image for text recognition."
+            }
+        }
+    }
+
+    /// Runs Vision text recognition. Call from a background queue; results are not tied to any actor.
+    static func recognizeText(from imageData: Data) throws -> String {
+        guard let cgImage = cgImage(fromPNGData: imageData) else {
+            throw Failure.couldNotCreateCGImage
+        }
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try handler.perform([request])
+
+        let observations = (request.results as? [VNRecognizedTextObservation]) ?? []
+        guard !observations.isEmpty else { return "" }
+
+        return readingOrderStrings(from: observations).joined(separator: "\n")
+    }
+
+    private static func cgImage(fromPNGData data: Data) -> CGImage? {
+        guard let nsImage = NSImage(data: data) else { return nil }
+        var rect = CGRect(origin: .zero, size: nsImage.size)
+        if let cg = nsImage.cgImage(forProposedRect: &rect, context: nil, hints: nil) {
+            return cg
+        }
+        guard let tiff = nsImage.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let cg = rep.cgImage
+        else { return nil }
+        return cg
+    }
+
+    /// Sorts observations for top-to-bottom, left-to-right reading in normalized Vision coordinates.
+    private static func readingOrderStrings(from observations: [VNRecognizedTextObservation]) -> [String] {
+        let lineTolerance: CGFloat = 0.02
+        let sorted = observations.sorted { a, b in
+            let ab = a.boundingBox
+            let bb = b.boundingBox
+            if abs(ab.midY - bb.midY) < lineTolerance {
+                return ab.minX < bb.minX
+            }
+            return ab.maxY > bb.maxY
+        }
+        return sorted.compactMap { observation in
+            observation.topCandidates(1).first?.string
+        }
+    }
+}

--- a/StickNote/Utils/String.swift
+++ b/StickNote/Utils/String.swift
@@ -1,5 +1,11 @@
 import AppKit
 
+/// Default width for ``String.wrappingLongLinesAtWordBoundaries()`` in plain-text notes.
+enum NoteLineWrap {
+    /// Hard-wrap lines longer than this at spaces; long unbroken tokens stay on one line.
+    static let maxCharactersPerLine = 80
+}
+
 extension String {
     public func truncate(_ maxLength: Int, maxLines: Int = 1) -> String {
         if self.count == 0 {
@@ -48,6 +54,49 @@ extension String {
             let withoutLeadingDeduction = index > refIdx ? line.removingLeadingWhitespace(upTo: n) : line
             return withoutLeadingDeduction.removingTrailingWhitespaceFromLine()
         }.joined(separator: "\n")
+    }
+
+    /// Wraps each line that exceeds `maxCharactersPerLine` by breaking only at whitespace between words.
+    /// Runs of spaces collapse to single spaces inside wrapped segments; lines already short enough are unchanged.
+    func wrappingLongLinesAtWordBoundaries(maxCharactersPerLine: Int = NoteLineWrap.maxCharactersPerLine) -> String {
+        guard maxCharactersPerLine > 0 else { return self }
+        return components(separatedBy: "\n").map { $0.wrappingSingleLineAtWordBoundaries(maxCharactersPerLine: maxCharactersPerLine) }.joined(separator: "\n")
+    }
+
+    private func wrappingSingleLineAtWordBoundaries(maxCharactersPerLine: Int) -> String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return self }
+
+        let words = trimmed.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard !words.isEmpty else { return self }
+
+        var lines: [String] = []
+        var current = ""
+
+        func appendLine(_ line: String) {
+            if !line.isEmpty { lines.append(line) }
+        }
+
+        for word in words {
+            if word.count > maxCharactersPerLine {
+                appendLine(current)
+                current = ""
+                lines.append(word)
+                continue
+            }
+            if current.isEmpty {
+                current = word
+                continue
+            }
+            if current.count + 1 + word.count <= maxCharactersPerLine {
+                current += " " + word
+            } else {
+                appendLine(current)
+                current = word
+            }
+        }
+        appendLine(current)
+        return lines.joined(separator: "\n")
     }
 
     fileprivate var leadingWhitespaceCount: Int {

--- a/StickNote/Utils/String.swift
+++ b/StickNote/Utils/String.swift
@@ -31,4 +31,51 @@ extension String {
         return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "")
     }
 
+    /// Trims plain-text notes: a single line is trimmed at both ends. For multiple lines, trailing
+    /// whitespace is removed from every line; the first line that has leading whitespace defines `n`,
+    /// and each following line has at most `n` leading whitespace characters removed from its start.
+    func trimmingNoteWhitespace() -> String {
+        if isEmpty { return self }
+        let lines = components(separatedBy: "\n")
+        if lines.count == 1 {
+            return lines[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard let refIdx = lines.firstIndex(where: { $0.leadingWhitespaceCount > 0 }) else {
+            return lines.map { $0.removingTrailingWhitespaceFromLine() }.joined(separator: "\n")
+        }
+        let n = lines[refIdx].leadingWhitespaceCount
+        return lines.enumerated().map { index, line in
+            let withoutLeadingDeduction = index > refIdx ? line.removingLeadingWhitespace(upTo: n) : line
+            return withoutLeadingDeduction.removingTrailingWhitespaceFromLine()
+        }.joined(separator: "\n")
+    }
+
+    fileprivate var leadingWhitespaceCount: Int {
+        var count = 0
+        for ch in self {
+            guard ch.isWhitespace else { break }
+            count += 1
+        }
+        return count
+    }
+
+    fileprivate func removingLeadingWhitespace(upTo maxCount: Int) -> String {
+        guard maxCount > 0 else { return self }
+        var remaining = maxCount
+        var result = self
+        while remaining > 0, let first = result.first, first.isWhitespace {
+            result.removeFirst()
+            remaining -= 1
+        }
+        return result
+    }
+
+    fileprivate func removingTrailingWhitespaceFromLine() -> String {
+        var result = self
+        while let last = result.last, last.isWhitespace {
+            result.removeLast()
+        }
+        return result
+    }
+
 }


### PR DESCRIPTION
## Summary

- **Plain text**: Trim whitespace and word-wrap actions (context menu and paste-related settings); Settings layout adjusted for the new options.
- **UX**: Light border on note windows when the window is not key so edges stay visible without relying on shadow alone.
- **OCR**: On-device text recognition for image notes using Vision (`VNRecognizeTextRequest`). Context menu action replaces the embedded image with recognized text after a destructive confirmation; recognition runs off the main thread; empty or failed recognition surfaces alerts.

## Commits

- Add plain-text trim whitespace (menu + paste setting)
- Add word-wrap for plain text (menu, paste setting, taller Settings)
- Add subtle border when note window is not key
- Add OCR for image notes (Vision)

Made with [Cursor](https://cursor.com)